### PR TITLE
 Add and apply solidity linter

### DIFF
--- a/ .gitattributes
+++ b/ .gitattributes
@@ -1,0 +1,1 @@
++*.sol linguist-language=Solidity

--- a/.solhint.json
+++ b/.solhint.json
@@ -1,0 +1,17 @@
+{
+    "extends": "default",
+    "rules": {
+        "bracket-align": "warn",
+        "code-complexity": "warn",
+        "const-name-snakecase": "warn",
+        "expression-indent": "warn",
+        "function-max-lines": "warn",
+        "statement-indent": "warn",
+        "indent": ["warn", 4],
+        "quotes": ["error", "double"],
+        "max-line-length": ["warn", 120],
+        "separate-by-one-line-in-contract": "warn",
+        "space-after-comma": "warn",
+        "func-order": "warn"
+    }
+}

--- a/contracts/B0x.sol
+++ b/contracts/B0x.sol
@@ -1,7 +1,7 @@
 
 pragma solidity ^0.4.24;
 
-import './modules/B0xStorage.sol';
+import "./modules/B0xStorage.sol";
 
 // This interface is meant to used with the deployed B0xProxy contract (modules/B0xProxyContracts.sol) address.
 // js example: var b0x = await B0x.at((await B0xProxy.deployed()).address);

--- a/contracts/B0xTo0x.sol
+++ b/contracts/B0xTo0x.sol
@@ -1,11 +1,11 @@
 
 pragma solidity ^0.4.24;
 
-import 'openzeppelin-solidity/contracts/math/SafeMath.sol';
-import './tokens/EIP20.sol';
-import './tokens/EIP20Wrapper.sol';
-import './modifiers/B0xOwnable.sol';
-import './shared/Debugger.sol';
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+import "./tokens/EIP20.sol";
+import "./tokens/EIP20Wrapper.sol";
+import "./modifiers/B0xOwnable.sol";
+import "./shared/Debugger.sol";
 
 interface Exchange_Interface {
     event LogError(uint8 indexed errorId, bytes32 indexed orderHash);
@@ -153,7 +153,7 @@ contract B0xTo0x is EIP20Wrapper, Debugger, B0xOwnable {
         }
 
         uint8 v;
-	    bytes32 r;
+        bytes32 r;
         bytes32 s;
         (v, r, s) = getSignatureParts(signature);
 

--- a/contracts/B0xVault.sol
+++ b/contracts/B0xVault.sol
@@ -1,8 +1,8 @@
 
 pragma solidity ^0.4.24;
 
-import './tokens/EIP20Wrapper.sol';
-import './modifiers/B0xOwnable.sol';
+import "./tokens/EIP20Wrapper.sol";
+import "./modifiers/B0xOwnable.sol";
 
 contract B0xVault is EIP20Wrapper, B0xOwnable {
 

--- a/contracts/migrations/Migrations.sol
+++ b/contracts/migrations/Migrations.sol
@@ -1,24 +1,27 @@
 
 pragma solidity ^0.4.24;
 
+
 contract Migrations {
-  address public owner;
-  uint public last_completed_migration;
+    address public owner;
+// solhint-disable-next-line var-name-mixedcase
+    uint public last_completed_migration;
 
-  modifier restricted() {
-    if (msg.sender == owner) _;
-  }
+    modifier restricted() {
+        if (msg.sender == owner) _;
+    }
 
-  constructor() public {
-    owner = msg.sender;
-  }
+    constructor() public {
+        owner = msg.sender;
+    }
 
-  function setCompleted(uint completed) public restricted {
-    last_completed_migration = completed;
-  }
+    function setCompleted(uint completed) public restricted {
+        last_completed_migration = completed;
+    }
 
-  function upgrade(address new_address) public restricted {
-    Migrations upgraded = Migrations(new_address);
-    upgraded.setCompleted(last_completed_migration);
-  }
+// solhint-disable-next-line func-param-name-mixedcase
+    function upgrade(address new_address) public restricted {
+        Migrations upgraded = Migrations(new_address);
+        upgraded.setCompleted(last_completed_migration);
+    }
 }

--- a/contracts/modifiers/B0xOwnable.sol
+++ b/contracts/modifiers/B0xOwnable.sol
@@ -1,7 +1,8 @@
 
 pragma solidity ^0.4.24;
 
-import 'openzeppelin-solidity/contracts/ownership/Ownable.sol';
+import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+
 
 // This provides a gatekeeping modifier for functions that can only be used by the b0x contract
 // Since it inherits Ownable provides typical ownership functionality with a slight modification to the transferOwnership function

--- a/contracts/modifiers/EMACollector.sol
+++ b/contracts/modifiers/EMACollector.sol
@@ -1,7 +1,8 @@
 
 pragma solidity ^0.4.24;
 
-import 'openzeppelin-solidity/contracts/math/SafeMath.sol';
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+
 
 // supports a single EMA calculated for the inheriting contract
 contract EMACollector {
@@ -29,13 +30,13 @@ contract EMACollector {
 
         // calculate new EMA
         emaValue = 
-                SafeMath.sub(
-                    SafeMath.add(
-                        value / (emaPeriods + 1) * 2,   // no overflow
-                        emaValue
-                    ),
-                    emaValue / (emaPeriods + 1) * 2     // no overflow
-                );
+            SafeMath.sub(
+                SafeMath.add(
+                    value / (emaPeriods + 1) * 2,   // no overflow
+                    emaValue
+                ),
+                emaValue / (emaPeriods + 1) * 2     // no overflow
+            );
         //emit EMAUpdated(emaValue);
     }
 }

--- a/contracts/modifiers/GasRefunder.sol
+++ b/contracts/modifiers/GasRefunder.sol
@@ -1,7 +1,8 @@
 
 pragma solidity ^0.4.24;
 
-import 'openzeppelin-solidity/contracts/math/SafeMath.sol';
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+
 
 contract GasRefunder {
     using SafeMath for uint256;

--- a/contracts/modifiers/GasTracker.sol
+++ b/contracts/modifiers/GasTracker.sol
@@ -1,6 +1,7 @@
 
 pragma solidity ^0.4.24;
 
+
 contract GasTracker {
 
     uint internal gasUsed;

--- a/contracts/modifiers/Upgradeable.sol
+++ b/contracts/modifiers/Upgradeable.sol
@@ -1,9 +1,10 @@
 
 pragma solidity ^0.4.24;
 
-import 'openzeppelin-solidity/contracts/ownership/Ownable.sol';
+import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 
-import '../tokens/EIP20.sol';
+import "../tokens/EIP20.sol";
+
 
 /**
  * @title Upgradeable

--- a/contracts/modules/B0xLoanHealth.sol
+++ b/contracts/modules/B0xLoanHealth.sol
@@ -1,14 +1,15 @@
 
 pragma solidity ^0.4.24;
 
-import 'openzeppelin-solidity/contracts/math/Math.sol';
+import "openzeppelin-solidity/contracts/math/Math.sol";
 
-import './B0xStorage.sol';
-import './B0xProxyContracts.sol';
-import '../shared/InternalFunctions.sol';
+import "./B0xStorage.sol";
+import "./B0xProxyContracts.sol";
+import "../shared/InternalFunctions.sol";
 
-import '../B0xVault.sol';
-import '../oracle/Oracle_Interface.sol';
+import "../B0xVault.sol";
+import "../oracle/Oracle_Interface.sol";
+
 
 contract B0xLoanHealth is B0xStorage, Proxiable, InternalFunctions {
     using SafeMath for uint256;
@@ -43,13 +44,13 @@ contract B0xLoanHealth is B0xStorage, Proxiable, InternalFunctions {
     {
         LoanOrder memory loanOrder = orders[loanOrderHash];
         if (loanOrder.maker == address(0)) {
-            return intOrRevert(0,46); // revert("B0xLoanHealth::payInterest: loanOrder.maker == address(0)");
+            return intOrRevert(0, 46); // revert("B0xLoanHealth::payInterest: loanOrder.maker == address(0)");
         }
 
         // can still pay any unpaid accured interest after a loan has closed
         LoanPosition memory loanPosition = loanPositions[loanOrderHash][trader];
         if (loanPosition.loanTokenAmountFilled == 0) {
-            return intOrRevert(0,52); // revert("B0xLoanHealth::payInterest: loanPosition.loanTokenAmountFilled == 0");
+            return intOrRevert(0, 52); // revert("B0xLoanHealth::payInterest: loanPosition.loanTokenAmountFilled == 0");
         }
         
         uint amountPaid = _payInterest(
@@ -81,12 +82,12 @@ contract B0xLoanHealth is B0xStorage, Proxiable, InternalFunctions {
 
         LoanPosition storage loanPosition = loanPositions[loanOrderHash][trader];
         if (loanPosition.loanTokenAmountFilled == 0 || !loanPosition.active) {
-            return boolOrRevert(false,84); // revert("B0xLoanHealth::liquidatePosition: loanPosition.loanTokenAmountFilled == 0 || !loanPosition.active");
+            return boolOrRevert(false, 84); // revert("B0xLoanHealth::liquidatePosition: loanPosition.loanTokenAmountFilled == 0 || !loanPosition.active");
         }
 
         LoanOrder memory loanOrder = orders[loanOrderHash];
         if (loanOrder.maker == address(0)) {
-            return boolOrRevert(false,89); // revert("B0xLoanHealth::liquidatePosition: loanOrder.maker == address(0)");
+            return boolOrRevert(false, 89); // revert("B0xLoanHealth::liquidatePosition: loanOrder.maker == address(0)");
         }
 
         if (DEBUG_MODE) {
@@ -105,7 +106,7 @@ contract B0xLoanHealth is B0xStorage, Proxiable, InternalFunctions {
             );
 
             if (loanTokenAmount == 0) {
-                return boolOrRevert(false,108); // revert("B0xLoanHealth::liquidatePosition: loanTokenAmount == 0");
+                return boolOrRevert(false, 108); // revert("B0xLoanHealth::liquidatePosition: loanTokenAmount == 0");
             }
 
             // the loan token becomes the new position token
@@ -124,7 +125,7 @@ contract B0xLoanHealth is B0xStorage, Proxiable, InternalFunctions {
                         loanPosition.positionTokenAmountFilled,
                         loanPosition.collateralTokenAmountFilled,
                         loanOrder.maintenanceMarginAmount)) {
-                    return boolOrRevert(false,127); // revert("B0xLoanHealth::liquidatePosition: liquidation not allowed");
+                    return boolOrRevert(false, 127); // revert("B0xLoanHealth::liquidatePosition: liquidation not allowed");
                 }
             }
         }
@@ -158,7 +159,6 @@ contract B0xLoanHealth is B0xStorage, Proxiable, InternalFunctions {
     /*
     * Constant public functions
     */
-
     /// @dev Checks the conditions for liquidation with the oracle
     /// @param loanOrderHash A unique hash representing the loan order
     /// @param trader The trader of the position
@@ -268,7 +268,6 @@ contract B0xLoanHealth is B0xStorage, Proxiable, InternalFunctions {
     /*
     * Internal functions
     */
-
     function _payInterest(
         LoanOrder loanOrder,
         LoanPosition loanPosition)
@@ -291,7 +290,7 @@ contract B0xLoanHealth is B0xStorage, Proxiable, InternalFunctions {
                 orders[loanOrder.loanOrderHash].oracleAddress,
                 amountPaid
             )) {
-                return intOrRevert(0,294); // revert("B0xLoanHealth::_payInterest: B0xVault.withdrawToken failed");
+                return intOrRevert(0, 294); // revert("B0xLoanHealth::_payInterest: B0xVault.withdrawToken failed");
             }
 
             // calls the oracle to signal processing of the interest (ie: paying the lender, retaining fees)
@@ -303,7 +302,7 @@ contract B0xLoanHealth is B0xStorage, Proxiable, InternalFunctions {
                 amountPaid,
                 gasUsed // initial used gas, collected in modifier
             )) {
-                return intOrRevert(0,306); // revert("B0xLoanHealth::_payInterest: Oracle_Interface.didPayInterest failed");
+                return intOrRevert(0, 306); // revert("B0xLoanHealth::_payInterest: Oracle_Interface.didPayInterest failed");
             }
         }
 
@@ -326,12 +325,12 @@ contract B0xLoanHealth is B0xStorage, Proxiable, InternalFunctions {
     {
         LoanPosition storage loanPosition = loanPositions[loanOrderHash][msg.sender];
         if (loanPosition.loanTokenAmountFilled == 0 || !loanPosition.active) {
-            return boolOrRevert(false,329); // revert("B0xLoanHealth::_closeLoan: loanPosition.loanTokenAmountFilled == 0 || !loanPosition.active");
+            return boolOrRevert(false, 329); // revert("B0xLoanHealth::_closeLoan: loanPosition.loanTokenAmountFilled == 0 || !loanPosition.active");
         }
 
         LoanOrder memory loanOrder = orders[loanOrderHash];
         if (loanOrder.maker == address(0)) {
-            return boolOrRevert(false,334); // revert("B0xLoanHealth::_closeLoan: loanOrder.maker == address(0)");
+            return boolOrRevert(false, 334); // revert("B0xLoanHealth::_closeLoan: loanOrder.maker == address(0)");
         }
 
         // If the position token is not the loan token, then we need to buy back the loan token prior to closing the loan.
@@ -345,7 +344,7 @@ contract B0xLoanHealth is B0xStorage, Proxiable, InternalFunctions {
             );
 
             if (loanTokenAmount == 0) {
-                return boolOrRevert(false,348); // revert("B0xLoanHealth::_closeLoan: loanTokenAmount == 0");
+                return boolOrRevert(false, 348); // revert("B0xLoanHealth::_closeLoan: loanTokenAmount == 0");
             }
 
             // the loan token becomes the new position token
@@ -384,14 +383,14 @@ contract B0xLoanHealth is B0xStorage, Proxiable, InternalFunctions {
             loanPosition.loanStartUnixTimestampSec)
             .sub(interestPaid[loanOrder.loanOrderHash][loanPosition.trader]);
         
-	    // refund any unused interest to the trader
+        // refund any unused interest to the trader
         if (totalInterestToRefund > 0) {
             if (! B0xVault(VAULT_CONTRACT).withdrawToken(
                 loanOrder.interestTokenAddress,
                 loanPosition.trader,
                 totalInterestToRefund
             )) {
-                return boolOrRevert(false,394); // revert("B0xLoanHealth::_finalizeLoan: B0xVault.withdrawToken interest failed");
+                return boolOrRevert(false, 394); // revert("B0xLoanHealth::_finalizeLoan: B0xVault.withdrawToken interest failed");
             }
         }
 
@@ -404,7 +403,7 @@ contract B0xLoanHealth is B0xStorage, Proxiable, InternalFunctions {
                 loanOrder.oracleAddress,
                 loanPosition.collateralTokenAmountFilled
             )) {
-                return boolOrRevert(false,407); // revert("B0xLoanHealth::_finalizeLoan: B0xVault.withdrawToken (cover losses) failed");
+                return boolOrRevert(false, 407); // revert("B0xLoanHealth::_finalizeLoan: B0xVault.withdrawToken (cover losses) failed");
             }
 
             uint loanTokenAmountCovered;
@@ -427,7 +426,7 @@ contract B0xLoanHealth is B0xStorage, Proxiable, InternalFunctions {
             loanPosition.trader,
             loanPosition.collateralTokenAmountFilled
         )) {
-            return boolOrRevert(false,430); // revert("B0xLoanHealth::_finalizeLoan: B0xVault.withdrawToken collateral failed");
+            return boolOrRevert(false, 430); // revert("B0xLoanHealth::_finalizeLoan: B0xVault.withdrawToken collateral failed");
         }
 
         // send remaining loan token back to the lender
@@ -436,7 +435,7 @@ contract B0xLoanHealth is B0xStorage, Proxiable, InternalFunctions {
             loanPosition.lender,
             loanPosition.positionTokenAmountFilled
         )) {
-            return boolOrRevert(false,439); // revert("B0xLoanHealth::_finalizeLoan: B0xVault.withdrawToken loan failed");
+            return boolOrRevert(false, 439); // revert("B0xLoanHealth::_finalizeLoan: B0xVault.withdrawToken loan failed");
         }
 
         if (! Oracle_Interface(loanOrder.oracleAddress).didCloseLoan(
@@ -445,7 +444,7 @@ contract B0xLoanHealth is B0xStorage, Proxiable, InternalFunctions {
             isLiquidation,
             gasUsed
         )) {
-            return boolOrRevert(false,448); // revert("B0xLoanHealth::_finalizeLoan: Oracle_Interface.didCloseLoan failed");
+            return boolOrRevert(false, 448); // revert("B0xLoanHealth::_finalizeLoan: Oracle_Interface.didCloseLoan failed");
         }
 
         // set this loan to inactive

--- a/contracts/modules/B0xLoanMaintenance.sol
+++ b/contracts/modules/B0xLoanMaintenance.sol
@@ -1,14 +1,15 @@
 
 pragma solidity ^0.4.24;
 
-import 'openzeppelin-solidity/contracts/math/Math.sol';
+import "openzeppelin-solidity/contracts/math/Math.sol";
 
-import './B0xStorage.sol';
-import './B0xProxyContracts.sol';
-import '../shared/InternalFunctions.sol';
+import "./B0xStorage.sol";
+import "./B0xProxyContracts.sol";
+import "../shared/InternalFunctions.sol";
 
-import '../B0xVault.sol';
-import '../oracle/Oracle_Interface.sol';
+import "../B0xVault.sol";
+import "../oracle/Oracle_Interface.sol";
+
 
 contract B0xLoanMaintenance is B0xStorage, Proxiable, InternalFunctions {
     using SafeMath for uint256;
@@ -42,20 +43,20 @@ contract B0xLoanMaintenance is B0xStorage, Proxiable, InternalFunctions {
     {
         LoanOrder memory loanOrder = orders[loanOrderHash];
         if (loanOrder.maker == address(0)) {
-            return boolOrRevert(false,45); // revert("B0xLoanHealth::depositCollateral: loanOrder.maker == address(0)");
+            return boolOrRevert(false, 45); // revert("B0xLoanHealth::depositCollateral: loanOrder.maker == address(0)");
         }
 
         if (block.timestamp >= loanOrder.expirationUnixTimestampSec) {
-            return boolOrRevert(false,49); // revert("B0xLoanHealth::depositCollateral: block.timestamp >= loanOrder.expirationUnixTimestampSec");
+            return boolOrRevert(false, 49); // revert("B0xLoanHealth::depositCollateral: block.timestamp >= loanOrder.expirationUnixTimestampSec");
         }
 
         LoanPosition storage loanPosition = loanPositions[loanOrderHash][msg.sender];
         if (loanPosition.loanTokenAmountFilled == 0 || !loanPosition.active) {
-            return boolOrRevert(false,54); // revert("B0xLoanHealth::depositCollateral: loanPosition.loanTokenAmountFilled == 0 || !loanPosition.active");
+            return boolOrRevert(false, 54); // revert("B0xLoanHealth::depositCollateral: loanPosition.loanTokenAmountFilled == 0 || !loanPosition.active");
         }
 
         if (collateralTokenFilled != loanPosition.collateralTokenAddressFilled) {
-            return boolOrRevert(false,58); // revert("B0xLoanHealth::depositCollateral: collateralTokenFilled != loanPosition.collateralTokenAddressFilled");
+            return boolOrRevert(false, 58); // revert("B0xLoanHealth::depositCollateral: collateralTokenFilled != loanPosition.collateralTokenAddressFilled");
         }
 
         if (! B0xVault(VAULT_CONTRACT).depositToken(
@@ -63,7 +64,7 @@ contract B0xLoanMaintenance is B0xStorage, Proxiable, InternalFunctions {
             msg.sender,
             depositAmount
         )) {
-            return boolOrRevert(false,66); // revert("B0xLoanHealth::depositCollateral: B0xVault.depositToken collateral failed");
+            return boolOrRevert(false, 66); // revert("B0xLoanHealth::depositCollateral: B0xVault.depositToken collateral failed");
         }
 
         loanPosition.collateralTokenAmountFilled = loanPosition.collateralTokenAmountFilled.add(depositAmount);
@@ -73,7 +74,7 @@ contract B0xLoanMaintenance is B0xStorage, Proxiable, InternalFunctions {
             msg.sender,
             gasUsed // initial used gas, collected in modifier
         )) {
-            return boolOrRevert(false,76); // revert("B0xLoanHealth::depositCollateral: Oracle_Interface.didDepositCollateral failed");
+            return boolOrRevert(false, 76); // revert("B0xLoanHealth::depositCollateral: Oracle_Interface.didDepositCollateral failed");
         }
 
         return true;
@@ -95,16 +96,16 @@ contract B0xLoanMaintenance is B0xStorage, Proxiable, InternalFunctions {
     {
         LoanOrder memory loanOrder = orders[loanOrderHash];
         if (loanOrder.maker == address(0)) {
-            return intOrRevert(0,98); // revert("B0xLoanHealth::withdrawExcessCollateral: loanOrder.maker == address(0)");
+            return intOrRevert(0, 98); // revert("B0xLoanHealth::withdrawExcessCollateral: loanOrder.maker == address(0)");
         }
 
         LoanPosition storage loanPosition = loanPositions[loanOrderHash][msg.sender];
         if (loanPosition.loanTokenAmountFilled == 0 || !loanPosition.active) {
-            return intOrRevert(0,103); // revert("B0xLoanHealth::withdrawExcessCollateral: loanPosition.loanTokenAmountFilled == 0 || !loanPosition.active");
+            return intOrRevert(0, 103); // revert("B0xLoanHealth::withdrawExcessCollateral: loanPosition.loanTokenAmountFilled == 0 || !loanPosition.active");
         }
 
         if (collateralTokenFilled != loanPosition.collateralTokenAddressFilled) {
-            return intOrRevert(0,107); // revert("B0xLoanHealth::withdrawExcessCollateral: collateralTokenFilled != loanPosition.collateralTokenAddressFilled");
+            return intOrRevert(0, 107); // revert("B0xLoanHealth::withdrawExcessCollateral: collateralTokenFilled != loanPosition.collateralTokenAddressFilled");
         }
 
         // the new collateral amount must be enough to satify the initial margin requirement of the loan
@@ -116,7 +117,7 @@ contract B0xLoanMaintenance is B0xStorage, Proxiable, InternalFunctions {
             loanOrder.initialMarginAmount
         );
         if (initialCollateralTokenAmount == 0 || initialCollateralTokenAmount >= loanPosition.collateralTokenAmountFilled) {
-            return intOrRevert(0,119); // revert("B0xLoanHealth::withdrawExcessCollateral: initialCollateralTokenAmount == 0 || initialCollateralTokenAmount >= loanPosition.collateralTokenAmountFilled");
+            return intOrRevert(0, 119); // revert("B0xLoanHealth::withdrawExcessCollateral: initialCollateralTokenAmount == 0 || initialCollateralTokenAmount >= loanPosition.collateralTokenAmountFilled");
         }
 
         excessCollateral = Math.min256(withdrawAmount, loanPosition.collateralTokenAmountFilled-initialCollateralTokenAmount);
@@ -127,7 +128,7 @@ contract B0xLoanMaintenance is B0xStorage, Proxiable, InternalFunctions {
             msg.sender,
             excessCollateral
         )) {
-            return intOrRevert(0,130); // revert("B0xLoanHealth::withdrawExcessCollateral: B0xVault.withdrawToken collateral failed");
+            return intOrRevert(0, 130); // revert("B0xLoanHealth::withdrawExcessCollateral: B0xVault.withdrawToken collateral failed");
         }
 
         // update stored collateral amount
@@ -138,7 +139,7 @@ contract B0xLoanMaintenance is B0xStorage, Proxiable, InternalFunctions {
             msg.sender,
             gasUsed // initial used gas, collected in modifier
         )) {
-            return intOrRevert(0,141); // revert("B0xLoanHealth::withdrawExcessCollateral: Oracle_Interface.didWithdrawCollateral failed");
+            return intOrRevert(0, 141); // revert("B0xLoanHealth::withdrawExcessCollateral: Oracle_Interface.didWithdrawCollateral failed");
         }
     }
 
@@ -157,20 +158,20 @@ contract B0xLoanMaintenance is B0xStorage, Proxiable, InternalFunctions {
     {
         LoanOrder memory loanOrder = orders[loanOrderHash];
         if (loanOrder.maker == address(0)) {
-            return boolOrRevert(false,160); // revert("B0xLoanHealth::changeCollateral: loanOrder.maker == address(0)");
+            return boolOrRevert(false, 160); // revert("B0xLoanHealth::changeCollateral: loanOrder.maker == address(0)");
         }
 
         LoanPosition storage loanPosition = loanPositions[loanOrderHash][msg.sender];
         if (loanPosition.loanTokenAmountFilled == 0 || !loanPosition.active) {
-            return boolOrRevert(false,165); // revert("B0xLoanHealth::changeCollateral: loanPosition.loanTokenAmountFilled == 0 || !loanPosition.active");
+            return boolOrRevert(false, 165); // revert("B0xLoanHealth::changeCollateral: loanPosition.loanTokenAmountFilled == 0 || !loanPosition.active");
         }
 
         if (collateralTokenFilled == address(0) || collateralTokenFilled == loanPosition.collateralTokenAddressFilled) {
-            return boolOrRevert(false,169); // revert("B0xLoanHealth::changeCollateral: collateralTokenFilled == address(0) || collateralTokenFilled == loanPosition.collateralTokenAddressFilled");
+            return boolOrRevert(false, 169); // revert("B0xLoanHealth::changeCollateral: collateralTokenFilled == address(0) || collateralTokenFilled == loanPosition.collateralTokenAddressFilled");
         }
 
         if (block.timestamp >= loanOrder.expirationUnixTimestampSec) {
-            return boolOrRevert(false,173); // revert("B0xLoanHealth::changeCollateral: block.timestamp >= loanOrder.expirationUnixTimestampSec");
+            return boolOrRevert(false, 173); // revert("B0xLoanHealth::changeCollateral: block.timestamp >= loanOrder.expirationUnixTimestampSec");
         }
 
         // the new collateral amount must be enough to satify the initial margin requirement of the loan
@@ -182,7 +183,7 @@ contract B0xLoanMaintenance is B0xStorage, Proxiable, InternalFunctions {
             loanOrder.initialMarginAmount
         );
         if (collateralTokenAmountFilled == 0) {
-            return boolOrRevert(false,185); // revert("B0xLoanHealth::changeCollateral: collateralTokenAmountFilled == 0");
+            return boolOrRevert(false, 185); // revert("B0xLoanHealth::changeCollateral: collateralTokenAmountFilled == 0");
         }
 
         // transfer the new collateral token from the trader to the vault
@@ -191,7 +192,7 @@ contract B0xLoanMaintenance is B0xStorage, Proxiable, InternalFunctions {
             msg.sender,
             collateralTokenAmountFilled
         )) {
-            return boolOrRevert(false,194); // revert("B0xLoanHealth::changeCollateral: B0xVault.depositToken new collateral failed");
+            return boolOrRevert(false, 194); // revert("B0xLoanHealth::changeCollateral: B0xVault.depositToken new collateral failed");
         }
 
         // transfer the old collateral token from the vault to the trader
@@ -200,7 +201,7 @@ contract B0xLoanMaintenance is B0xStorage, Proxiable, InternalFunctions {
             msg.sender,
             loanPosition.collateralTokenAmountFilled
         )) {
-            return boolOrRevert(false,203); // revert("B0xLoanHealth::changeCollateral: B0xVault.withdrawToken old collateral failed");
+            return boolOrRevert(false, 203); // revert("B0xLoanHealth::changeCollateral: B0xVault.withdrawToken old collateral failed");
         }
 
         loanPosition.collateralTokenAddressFilled = collateralTokenFilled;
@@ -211,7 +212,7 @@ contract B0xLoanMaintenance is B0xStorage, Proxiable, InternalFunctions {
             msg.sender,
             gasUsed // initial used gas, collected in modifier
         )) {
-            return boolOrRevert(false,214); // revert("B0xLoanHealth::changeCollateral: Oracle_Interface.didChangeCollateral failed");
+            return boolOrRevert(false, 214); // revert("B0xLoanHealth::changeCollateral: Oracle_Interface.didChangeCollateral failed");
         }
 
         return true;
@@ -236,7 +237,7 @@ contract B0xLoanMaintenance is B0xStorage, Proxiable, InternalFunctions {
             loanOrder,
             loanPosition);
         if (profitAmount == 0 || !isProfit) {
-            return intOrRevert(0,239); // revert("B0xLoanHealth::withdrawProfit: profitAmount == 0 || !isProfit");
+            return intOrRevert(0, 239); // revert("B0xLoanHealth::withdrawProfit: profitAmount == 0 || !isProfit");
         }
 
         // transfer profit to the trader
@@ -245,7 +246,7 @@ contract B0xLoanMaintenance is B0xStorage, Proxiable, InternalFunctions {
             msg.sender,
             profitAmount
         )) {
-            return intOrRevert(0,248); // revert("B0xLoanHealth::withdrawProfit: B0xVault.withdrawToken loan failed");
+            return intOrRevert(0, 248); // revert("B0xLoanHealth::withdrawProfit: B0xVault.withdrawToken loan failed");
         }
 
         // deduct profit from positionToken balance
@@ -257,7 +258,7 @@ contract B0xLoanMaintenance is B0xStorage, Proxiable, InternalFunctions {
             profitAmount,
             gasUsed // initial used gas, collected in modifier
         )) {
-            return intOrRevert(0,260); // revert("B0xLoanHealth::withdrawProfit: Oracle_Interface.didWithdrawProfit failed");
+            return intOrRevert(0, 260); // revert("B0xLoanHealth::withdrawProfit: Oracle_Interface.didWithdrawProfit failed");
         }
 
         emit LogWithdrawProfit(
@@ -273,7 +274,6 @@ contract B0xLoanMaintenance is B0xStorage, Proxiable, InternalFunctions {
     /*
     * Constant public functions
     */
-
     /// @dev Get the current profit/loss data of a position
     /// @param loanOrderHash A unique hash representing the loan order
     /// @param trader The trader of the position
@@ -298,7 +298,6 @@ contract B0xLoanMaintenance is B0xStorage, Proxiable, InternalFunctions {
     /*
     * Constant Internal functions
     */
-
     function _getProfitOrLoss(
         LoanOrder loanOrder,
         LoanPosition loanPosition)

--- a/contracts/modules/B0xOrderTaking.sol
+++ b/contracts/modules/B0xOrderTaking.sol
@@ -1,15 +1,16 @@
 
 pragma solidity ^0.4.24;
 
-import 'openzeppelin-solidity/contracts/math/Math.sol';
+import "openzeppelin-solidity/contracts/math/Math.sol";
 
-import './B0xStorage.sol';
-import './B0xProxyContracts.sol';
-import '../shared/InternalFunctions.sol';
+import "./B0xStorage.sol";
+import "./B0xProxyContracts.sol";
+import "../shared/InternalFunctions.sol";
 
-import '../B0xVault.sol';
-import '../oracle/OracleRegistry.sol';
-import '../oracle/Oracle_Interface.sol';
+import "../B0xVault.sol";
+import "../oracle/OracleRegistry.sol";
+import "../oracle/Oracle_Interface.sol";
+
 
 contract B0xOrderTaking is B0xStorage, Proxiable, InternalFunctions {
     using SafeMath for uint256;
@@ -132,7 +133,7 @@ contract B0xOrderTaking is B0xStorage, Proxiable, InternalFunctions {
     {
         LoanOrder memory loanOrder = orders[loanOrderHash];
         if (loanOrder.maker == address(0)) {
-            return intOrRevert(0,135); // revert("B0xOrderTaking::cancelLoanOrder: loanOrder.maker == address(0)");
+            return intOrRevert(0, 135); // revert("B0xOrderTaking::cancelLoanOrder: loanOrder.maker == address(0)");
         }
 
         require(loanOrder.maker == msg.sender);
@@ -416,7 +417,6 @@ contract B0xOrderTaking is B0xStorage, Proxiable, InternalFunctions {
     /*
     * Internal functions
     */
-
     function _takeLoanOrder(
         address[6] orderAddresses,
         uint[9] orderValues,
@@ -462,12 +462,12 @@ contract B0xOrderTaking is B0xStorage, Proxiable, InternalFunctions {
             loanOrder.loanOrderHash,
             signature
         )) {
-            return intOrRevert(0,463); // revert("B0xOrderTaking::_takeLoanOrder: signature invalid");
+            return intOrRevert(0, 463); // revert("B0xOrderTaking::_takeLoanOrder: signature invalid");
         }
 
         // makerRole (orderValues[7]) and takerRole must not be equal and must have a value <= 1
         if (orderValues[7] > 1 || takerRole > 1 || orderValues[7] == takerRole) {
-            return intOrRevert(0,468); // revert("B0xOrderTaking::_takeLoanOrder: orderValues[7] > 1 || takerRole > 1 || orderValues[7] == takerRole");
+            return intOrRevert(0, 468); // revert("B0xOrderTaking::_takeLoanOrder: orderValues[7] > 1 || takerRole > 1 || orderValues[7] == takerRole");
         }
 
         // A trader can only fill a portion or all of a loanOrder once:
@@ -475,7 +475,7 @@ contract B0xOrderTaking is B0xStorage, Proxiable, InternalFunctions {
         //  - this avoids potentially large loops when calculating margin reqirements and interest payments
         LoanPosition storage loanPosition = loanPositions[loanOrder.loanOrderHash][trader];
         if (loanPosition.loanTokenAmountFilled != 0) {
-            return intOrRevert(0,476); // revert("B0xOrderTaking::_takeLoanOrder: loanPosition.loanTokenAmountFilled != 0");
+            return intOrRevert(0, 476); // revert("B0xOrderTaking::_takeLoanOrder: loanPosition.loanTokenAmountFilled != 0");
         }     
 
         uint collateralTokenAmountFilled = _fillLoanOrder(
@@ -518,7 +518,7 @@ contract B0xOrderTaking is B0xStorage, Proxiable, InternalFunctions {
                 msg.sender,
                 gasUsed // initial used gas, collected in modifier
             )) {
-                return intOrRevert(0,519); // revert("B0xOrderTaking::_takeLoanOrder: Oracle_Interface.didTakeOrder failed");
+                return intOrRevert(0, 519); // revert("B0xOrderTaking::_takeLoanOrder: Oracle_Interface.didTakeOrder failed");
             }
         }
 
@@ -535,7 +535,7 @@ contract B0xOrderTaking is B0xStorage, Proxiable, InternalFunctions {
         returns (uint)
     {
         if (!_verifyLoanOrder(loanOrder, collateralTokenFilled, loanTokenAmountFilled)) {
-            return intOrRevert(0,536); // revert("B0xOrderTaking::_fillLoanOrder: loan verification failed");
+            return intOrRevert(0, 536); // revert("B0xOrderTaking::_fillLoanOrder: loan verification failed");
         }
 
         uint collateralTokenAmountFilled = _getInitialCollateralRequired(
@@ -546,7 +546,7 @@ contract B0xOrderTaking is B0xStorage, Proxiable, InternalFunctions {
             loanOrder.initialMarginAmount
         );
         if (collateralTokenAmountFilled == 0) {
-            return intOrRevert(0,547); // revert("B0xOrderTaking::_fillLoanOrder: collateralTokenAmountFilled == 0");
+            return intOrRevert(0, 547); // revert("B0xOrderTaking::_fillLoanOrder: collateralTokenAmountFilled == 0");
         }
 
         // deposit collateral token
@@ -555,7 +555,7 @@ contract B0xOrderTaking is B0xStorage, Proxiable, InternalFunctions {
             trader,
             collateralTokenAmountFilled
         )) {
-            return intOrRevert(loanTokenAmountFilled,556); // revert("B0xOrderTaking::_fillLoanOrder: B0xVault.depositToken collateral failed");
+            return intOrRevert(loanTokenAmountFilled, 556); // revert("B0xOrderTaking::_fillLoanOrder: B0xVault.depositToken collateral failed");
         }
 
         // total interest required if loan is kept until order expiration
@@ -573,7 +573,7 @@ contract B0xOrderTaking is B0xStorage, Proxiable, InternalFunctions {
             trader,
             totalInterestRequired
         )) {
-            return intOrRevert(loanTokenAmountFilled,574); // revert("B0xOrderTaking::_fillLoanOrder: B0xVault.depositToken interest failed");
+            return intOrRevert(loanTokenAmountFilled, 574); // revert("B0xOrderTaking::_fillLoanOrder: B0xVault.depositToken interest failed");
         }
 
         // deposit loan token
@@ -582,7 +582,7 @@ contract B0xOrderTaking is B0xStorage, Proxiable, InternalFunctions {
             lender,
             loanTokenAmountFilled
         )) {
-            return intOrRevert(loanTokenAmountFilled,583); // revert("B0xOrderTaking::_fillLoanOrder: B0xVault.depositToken loan failed");
+            return intOrRevert(loanTokenAmountFilled, 583); // revert("B0xOrderTaking::_fillLoanOrder: B0xVault.depositToken loan failed");
         }
 
         if (loanOrder.feeRecipientAddress != address(0)) {
@@ -595,7 +595,7 @@ contract B0xOrderTaking is B0xStorage, Proxiable, InternalFunctions {
                     loanOrder.feeRecipientAddress,
                     paidTraderFee
                 )) {
-                    return intOrRevert(loanTokenAmountFilled,596); // revert("B0xOrderTaking::_fillLoanOrder: B0xVault.transferTokenFrom traderRelayFee failed");
+                    return intOrRevert(loanTokenAmountFilled, 596); // revert("B0xOrderTaking::_fillLoanOrder: B0xVault.transferTokenFrom traderRelayFee failed");
                 }
             }
             if (loanOrder.lenderRelayFee > 0) {
@@ -607,7 +607,7 @@ contract B0xOrderTaking is B0xStorage, Proxiable, InternalFunctions {
                     loanOrder.feeRecipientAddress,
                     paidLenderFee
                 )) {
-                    return intOrRevert(0,608); // revert("B0xOrderTaking::_fillLoanOrder: B0xVault.transferTokenFrom lenderRelayFee failed");
+                    return intOrRevert(0, 608); // revert("B0xOrderTaking::_fillLoanOrder: B0xVault.transferTokenFrom lenderRelayFee failed");
                 }
             }
         }
@@ -623,34 +623,34 @@ contract B0xOrderTaking is B0xStorage, Proxiable, InternalFunctions {
         returns (bool)
     {
         if (loanOrder.maker == msg.sender) {
-            return boolOrRevert(false,624); // revert("B0xOrderTaking::_verifyLoanOrder: loanOrder.maker == msg.sender");
+            return boolOrRevert(false, 624); // revert("B0xOrderTaking::_verifyLoanOrder: loanOrder.maker == msg.sender");
         }
         if (loanOrder.loanTokenAddress == address(0) 
             || loanOrder.interestTokenAddress == address(0)
             || collateralTokenFilled == address(0)) {
-            return boolOrRevert(false,629); // revert("B0xOrderTaking::_verifyLoanOrder: loanOrder.loanTokenAddress == address(0) || loanOrder.interestTokenAddress == address(0) || collateralTokenFilled == address(0)");
+            return boolOrRevert(false, 629); // revert("B0xOrderTaking::_verifyLoanOrder: loanOrder.loanTokenAddress == address(0) || loanOrder.interestTokenAddress == address(0) || collateralTokenFilled == address(0)");
         }
 
         if (loanTokenAmountFilled > loanOrder.loanTokenAmount) {
-            return boolOrRevert(false,633); // revert("B0xOrderTaking::_verifyLoanOrder: loanTokenAmountFilled > loanOrder.loanTokenAmount");
+            return boolOrRevert(false, 633); // revert("B0xOrderTaking::_verifyLoanOrder: loanTokenAmountFilled > loanOrder.loanTokenAmount");
         }
 
         if (! OracleRegistry(ORACLE_REGISTRY_CONTRACT).hasOracle(loanOrder.oracleAddress)) {
-            return boolOrRevert(false,637); // revert("B0xOrderTaking::_verifyLoanOrder: OracleRegistry.hasOracle failed");
+            return boolOrRevert(false, 637); // revert("B0xOrderTaking::_verifyLoanOrder: OracleRegistry.hasOracle failed");
         }
 
         if (block.timestamp >= loanOrder.expirationUnixTimestampSec) {
             //LogError(uint8(Errors.ORDER_EXPIRED), 0, loanOrder.loanOrderHash);
-            return boolOrRevert(false,642); // revert("B0xOrderTaking::_verifyLoanOrder: block.timestamp >= loanOrder.expirationUnixTimestampSec");
+            return boolOrRevert(false, 642); // revert("B0xOrderTaking::_verifyLoanOrder: block.timestamp >= loanOrder.expirationUnixTimestampSec");
         }
 
         if (loanOrder.maintenanceMarginAmount == 0 || loanOrder.maintenanceMarginAmount >= loanOrder.initialMarginAmount) {
-            return boolOrRevert(false,646); // revert("B0xOrderTaking::_verifyLoanOrder: loanOrder.maintenanceMarginAmount == 0 || loanOrder.maintenanceMarginAmount >= loanOrder.initialMarginAmount");
+            return boolOrRevert(false, 646); // revert("B0xOrderTaking::_verifyLoanOrder: loanOrder.maintenanceMarginAmount == 0 || loanOrder.maintenanceMarginAmount >= loanOrder.initialMarginAmount");
         }
 
         uint remainingLoanTokenAmount = loanOrder.loanTokenAmount.sub(getUnavailableLoanTokenAmount(loanOrder.loanOrderHash));
         if (remainingLoanTokenAmount < loanTokenAmountFilled) {
-            return boolOrRevert(false,651); // revert("B0xOrderTaking::_verifyLoanOrder: remainingLoanTokenAmount < loanTokenAmountFilled");
+            return boolOrRevert(false, 651); // revert("B0xOrderTaking::_verifyLoanOrder: remainingLoanTokenAmount < loanTokenAmountFilled");
         }
 
         return true;

--- a/contracts/modules/B0xProxyContracts.sol
+++ b/contracts/modules/B0xProxyContracts.sol
@@ -1,8 +1,9 @@
 
 pragma solidity ^0.4.24;
 
-import 'openzeppelin-solidity/contracts/ownership/Ownable.sol';
-import './B0xStorage.sol';
+import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import "./B0xStorage.sol";
+
 
 contract Proxiable {
     mapping (bytes4 => address) public targets;
@@ -13,6 +14,7 @@ contract Proxiable {
         require(_target.delegatecall(bytes4(keccak256("initialize(address)")), _target));
     }
 }
+
 
 // b0x proxy
 contract B0xProxy is B0xStorage, Proxiable {
@@ -41,7 +43,6 @@ contract B0xProxy is B0xStorage, Proxiable {
     /*
      * Owner only functions
      */
-
     function replaceContract(
         address _target)
         public

--- a/contracts/modules/B0xStorage.sol
+++ b/contracts/modules/B0xStorage.sol
@@ -1,10 +1,11 @@
 
 pragma solidity ^0.4.24;
 
-import 'openzeppelin-solidity/contracts/ReentrancyGuard.sol';
-import 'openzeppelin-solidity/contracts/ownership/Ownable.sol';
-import '../shared/Debugger.sol';
-import '../modifiers/GasTracker.sol';
+import "openzeppelin-solidity/contracts/ReentrancyGuard.sol";
+import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import "../shared/Debugger.sol";
+import "../modifiers/GasTracker.sol";
+
 
 contract B0xObjects {
 
@@ -49,7 +50,6 @@ contract B0xObjects {
         uint interestTotalAccrued;
         uint interestPaidSoFar;
     }
-
 
     event LogLoanTaken (
         address lender,
@@ -122,7 +122,6 @@ contract B0xObjects {
         uint otherAmount
     );*/
 
-
     function buildLoanOrderStruct(
         bytes32 loanOrderHash,
         address[6] addrs,
@@ -170,14 +169,17 @@ contract B0xObjects {
     }*/
 }
 
+
 // b0x shared storage
 contract B0xStorage is B0xObjects, ReentrancyGuard, Ownable, GasTracker, Debugger {
     uint constant MAX_UINT = 2**256 - 1;
 
+/* solhint-disable var-name-mixedcase */
     address public B0X_TOKEN_CONTRACT;
     address public VAULT_CONTRACT;
     address public ORACLE_REGISTRY_CONTRACT;
     address public B0XTO0X_CONTRACT;
+/* solhint-enable var-name-mixedcase */
 
     mapping (bytes32 => LoanOrder) public orders; // mapping of loanOrderHash to taken loanOrders
     mapping (address => bytes32[]) public orderList; // mapping of lenders and trader addresses to array of loanOrderHashes

--- a/contracts/modules/B0xTradePlacing.sol
+++ b/contracts/modules/B0xTradePlacing.sol
@@ -1,17 +1,19 @@
 
 pragma solidity ^0.4.24;
 
-import 'openzeppelin-solidity/contracts/math/Math.sol';
+import "openzeppelin-solidity/contracts/math/Math.sol";
 
-import './B0xStorage.sol';
-import './B0xProxyContracts.sol';
-import '../shared/InternalFunctions.sol';
+import "./B0xStorage.sol";
+import "./B0xProxyContracts.sol";
+import "../shared/InternalFunctions.sol";
 
-import '../B0xVault.sol';
-import '../oracle/Oracle_Interface.sol';
+import "../B0xVault.sol";
+import "../oracle/Oracle_Interface.sol";
 
-import '../tokens/EIP20.sol';
+import "../tokens/EIP20.sol";
 
+
+// solhint-disable-next-line contract-name-camelcase
 interface B0xTo0x_Interface {
    function take0xTrade(
         address trader,
@@ -25,6 +27,7 @@ interface B0xTo0x_Interface {
             uint destTokenAmount,
             uint sourceTokenUsedAmount);
 }
+
 
 contract B0xTradePlacing is B0xStorage, Proxiable, InternalFunctions {
     using SafeMath for uint256;
@@ -56,16 +59,16 @@ contract B0xTradePlacing is B0xStorage, Proxiable, InternalFunctions {
     {
         LoanOrder memory loanOrder = orders[loanOrderHash];
         if (loanOrder.maker == address(0)) {
-            return intOrRevert(0,59); // revert("B0xTradePlacing::tradePositionWith0x: loanOrder.maker == address(0)");
+            return intOrRevert(0, 59); // revert("B0xTradePlacing::tradePositionWith0x: loanOrder.maker == address(0)");
         }
 
         if (block.timestamp >= loanOrder.expirationUnixTimestampSec) {
-            return intOrRevert(0,63); // revert("B0xTradePlacing::tradePositionWith0x: block.timestamp >= loanOrder.expirationUnixTimestampSec");
+            return intOrRevert(0, 63); // revert("B0xTradePlacing::tradePositionWith0x: block.timestamp >= loanOrder.expirationUnixTimestampSec");
         }
 
         LoanPosition storage loanPosition = loanPositions[loanOrderHash][msg.sender];
         if (loanPosition.loanTokenAmountFilled == 0 || !loanPosition.active) {
-            return intOrRevert(0,68); // revert("B0xTradePlacing::tradePositionWith0x: loanPosition.loanTokenAmountFilled == 0 || !loanPosition.active");
+            return intOrRevert(0, 68); // revert("B0xTradePlacing::tradePositionWith0x: loanPosition.loanTokenAmountFilled == 0 || !loanPosition.active");
         }
 
         // transfer the current position token to the B0xTo0x contract
@@ -73,7 +76,7 @@ contract B0xTradePlacing is B0xStorage, Proxiable, InternalFunctions {
             loanPosition.positionTokenAddressFilled,
             B0XTO0X_CONTRACT,
             loanPosition.positionTokenAmountFilled)) {
-            return intOrRevert(0,76); // revert("B0xTradePlacing::tradePositionWith0x: B0xVault.withdrawToken failed");
+            return intOrRevert(0, 76); // revert("B0xTradePlacing::tradePositionWith0x: B0xVault.withdrawToken failed");
         }
 
         address tradeTokenAddress;
@@ -87,7 +90,7 @@ contract B0xTradePlacing is B0xStorage, Proxiable, InternalFunctions {
             signiture0x);
 
         if (tradeTokenAmount == 0 || positionTokenUsedAmount != loanPosition.positionTokenAmountFilled) {
-            return intOrRevert(0,90); // revert("B0xTradePlacing::tradePositionWith0x: tradeTokenAmount == 0 || positionTokenUsedAmount != loanPosition.positionTokenAmountFilled");
+            return intOrRevert(0, 90); // revert("B0xTradePlacing::tradePositionWith0x: tradeTokenAmount == 0 || positionTokenUsedAmount != loanPosition.positionTokenAmountFilled");
         }
 
         if (DEBUG_MODE) {
@@ -105,7 +108,7 @@ contract B0xTradePlacing is B0xStorage, Proxiable, InternalFunctions {
                 loanPosition.positionTokenAmountFilled,
                 loanPosition.collateralTokenAmountFilled,
                 loanOrder.maintenanceMarginAmount)) {
-            return intOrRevert(0,108); // revert("B0xTradePlacing::tradePositionWith0x: liquidation required");
+            return intOrRevert(0, 108); // revert("B0xTradePlacing::tradePositionWith0x: liquidation required");
         }
 
         emit LogPositionTraded(
@@ -128,7 +131,7 @@ contract B0xTradePlacing is B0xStorage, Proxiable, InternalFunctions {
             tradeTokenAmount,
             gasUsed // initial used gas, collected in modifier
         )) {
-            return intOrRevert(0,131); // revert("B0xTradePlacing::tradePositionWith0x: Oracle_Interface.didTradePosition failed");
+            return intOrRevert(0, 131); // revert("B0xTradePlacing::tradePositionWith0x: Oracle_Interface.didTradePosition failed");
         }
 
         return tradeTokenAmount;
@@ -148,20 +151,20 @@ contract B0xTradePlacing is B0xStorage, Proxiable, InternalFunctions {
     {
         LoanOrder memory loanOrder = orders[loanOrderHash];
         if (loanOrder.maker == address(0)) {
-            return intOrRevert(0,151); // revert("B0xTradePlacing::tradePositionWithOracle: loanOrder.maker == address(0)");
+            return intOrRevert(0, 151); // revert("B0xTradePlacing::tradePositionWithOracle: loanOrder.maker == address(0)");
         }
 
         if (block.timestamp >= loanOrder.expirationUnixTimestampSec) {
-            return intOrRevert(0,155); // revert("B0xTradePlacing::tradePositionWithOracle: block.timestamp >= loanOrder.expirationUnixTimestampSec");
+            return intOrRevert(0, 155); // revert("B0xTradePlacing::tradePositionWithOracle: block.timestamp >= loanOrder.expirationUnixTimestampSec");
         }
 
         LoanPosition storage loanPosition = loanPositions[loanOrderHash][msg.sender];
         if (loanPosition.loanTokenAmountFilled == 0 || !loanPosition.active) {
-            return intOrRevert(0,160); // revert("B0xTradePlacing::tradePositionWithOracle: loanPosition.loanTokenAmountFilled == 0 || !loanPosition.active");
+            return intOrRevert(0, 160); // revert("B0xTradePlacing::tradePositionWithOracle: loanPosition.loanTokenAmountFilled == 0 || !loanPosition.active");
         }
 
         if (tradeTokenAddress == loanPosition.positionTokenAddressFilled) {
-            return intOrRevert(0,164); // revert("B0xTradePlacing::tradePositionWithOracle: tradeTokenAddress == loanPosition.positionTokenAddressFilled");
+            return intOrRevert(0, 164); // revert("B0xTradePlacing::tradePositionWithOracle: tradeTokenAddress == loanPosition.positionTokenAddressFilled");
         }
 
         if (DEBUG_MODE) {
@@ -179,7 +182,7 @@ contract B0xTradePlacing is B0xStorage, Proxiable, InternalFunctions {
                 loanPosition.positionTokenAmountFilled,
                 loanPosition.collateralTokenAmountFilled,
                 loanOrder.maintenanceMarginAmount)) {
-            return intOrRevert(0,182); // revert("B0xTradePlacing::tradePositionWithOracle: liquidation required");
+            return intOrRevert(0, 182); // revert("B0xTradePlacing::tradePositionWithOracle: liquidation required");
         }
 
         // check the current token balance of the oracle before sending token to be traded
@@ -196,11 +199,11 @@ contract B0xTradePlacing is B0xStorage, Proxiable, InternalFunctions {
         // It is assumed that all positionToken will be traded, so the remaining token balance of the oracle 
         // shouldn't be greater than the balance before we sent the token to be traded.
         if (balanceBeforeTrade < EIP20(loanPosition.positionTokenAddressFilled).balanceOf.gas(4999)(loanOrder.oracleAddress)) {
-            return intOrRevert(0,199); // revert("B0xTradePlacing::tradePositionWithOracle: balanceBeforeTrade is less");
+            return intOrRevert(0, 199); // revert("B0xTradePlacing::tradePositionWithOracle: balanceBeforeTrade is less");
         }
 
         if (tradeTokenAmount == 0) {
-            return intOrRevert(0,203); // revert("B0xTradePlacing::tradePositionWithOracle: tradeTokenAmount == 0");
+            return intOrRevert(0, 203); // revert("B0xTradePlacing::tradePositionWithOracle: tradeTokenAmount == 0");
         }
 
         emit LogPositionTraded(
@@ -223,7 +226,7 @@ contract B0xTradePlacing is B0xStorage, Proxiable, InternalFunctions {
             tradeTokenAmount,
             gasUsed // initial used gas, collected in modifier
         )) {
-            return intOrRevert(0,226); // revert("B0xTradePlacing::tradePositionWithOracle: Oracle_Interface.didTradePosition");
+            return intOrRevert(0, 226); // revert("B0xTradePlacing::tradePositionWithOracle: Oracle_Interface.didTradePosition");
         }
 
         return tradeTokenAmount;

--- a/contracts/oracle/B0xOracle.sol
+++ b/contracts/oracle/B0xOracle.sol
@@ -1,24 +1,28 @@
 
 pragma solidity ^0.4.24;
 
-import 'openzeppelin-solidity/contracts/math/SafeMath.sol';
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 
-import '../modifiers/B0xOwnable.sol';
+import "../modifiers/B0xOwnable.sol";
 
-import '../modifiers/EMACollector.sol';
-import '../modifiers/GasRefunder.sol';
-import '../B0xVault.sol';
-import '../shared/Debugger.sol';
+import "../modifiers/EMACollector.sol";
+import "../modifiers/GasRefunder.sol";
+import "../B0xVault.sol";
+import "../shared/Debugger.sol";
 
-import '../tokens/EIP20.sol';
-import '../tokens/EIP20Wrapper.sol';
-import './Oracle_Interface.sol';
+import "../tokens/EIP20.sol";
+import "../tokens/EIP20Wrapper.sol";
+import "./Oracle_Interface.sol";
 
+
+// solhint-disable-next-line contract-name-camelcase
 interface WETH_Interface {
     function deposit() external payable;
     function withdraw(uint wad) external;
 }
 
+
+// solhint-disable-next-line contract-name-camelcase
 interface KyberNetwork_Interface {
     /// @notice use token address ETH_TOKEN_ADDRESS for ether
     function getExpectedRate(
@@ -53,6 +57,7 @@ interface KyberNetwork_Interface {
         returns(uint);
 }
 
+
 contract B0xOracle is Oracle_Interface, EIP20Wrapper, EMACollector, GasRefunder, Debugger, B0xOwnable {
     using SafeMath for uint256;
 
@@ -84,11 +89,12 @@ contract B0xOracle is Oracle_Interface, EIP20Wrapper, EMACollector, GasRefunder,
     uint public minMaintenanceMarginAmount = 25;
 
     bool public isManualTradingAllowed = true;
-
+/* solhint-disable var-name-mixedcase */
     address public VAULT_CONTRACT;
     address public KYBER_CONTRACT;
     address public WETH_CONTRACT;
     address public B0X_TOKEN_CONTRACT;
+/* solhint-enable var-name-mixedcase */
 
     mapping (bytes32 => GasData[]) public gasRefunds; // // mapping of loanOrderHash to array of GasData
 
@@ -115,7 +121,6 @@ contract B0xOracle is Oracle_Interface, EIP20Wrapper, EMACollector, GasRefunder,
     }
 
     // standard functions
-
     function didTakeOrder(
         bytes32 loanOrderHash,
         address taker,
@@ -169,7 +174,7 @@ contract B0xOracle is Oracle_Interface, EIP20Wrapper, EMACollector, GasRefunder,
             interestTokenAddress,
             lender,
             amountOwed.sub(interestFee))) {
-            return boolOrRevert(false,170); // revert("B0xOracle::didPayInterest: _transferToken failed");
+            return boolOrRevert(false, 170); // revert("B0xOracle::didPayInterest: _transferToken failed");
         }
 
         // TODO: Block withdrawal below a certain amount
@@ -353,7 +358,8 @@ contract B0xOracle is Oracle_Interface, EIP20Wrapper, EMACollector, GasRefunder,
     {
         uint collateralTokenBalance = EIP20(collateralTokenAddress).balanceOf.gas(4999)(this); // Changes to state require at least 5000 gas
         if (collateralTokenBalance < collateralTokenAmountUsable) { // sanity check
-            voidOrRevert(354); return; // revert("B0xOracle::doTradeofCollateral: collateralTokenBalance < collateralTokenAmountUsable");
+            voidOrRevert(354);
+            return; // revert("B0xOracle::doTradeofCollateral: collateralTokenBalance < collateralTokenAmountUsable");
         }
 
         // TODO: If collateralTokenAddress is WETH, do just a single trade with funds combined with the insurance fund if needed
@@ -373,7 +379,8 @@ contract B0xOracle is Oracle_Interface, EIP20Wrapper, EMACollector, GasRefunder,
                 collateralTokenAddress,
                 VAULT_CONTRACT,
                 collateralTokenAmountUsable.sub(collateralTokenAmountUsed))) {
-                voidOrRevert(374); return; // revert("B0xOracle::doTradeofCollateral: _transferToken failed");
+                voidOrRevert(374);
+                return; // revert("B0xOracle::doTradeofCollateral: _transferToken failed");
             }
         }
 
@@ -411,13 +418,15 @@ contract B0xOracle is Oracle_Interface, EIP20Wrapper, EMACollector, GasRefunder,
         view
         returns (bool)
     {
-        return (getCurrentMarginAmount(
+        return (
+            getCurrentMarginAmount(
                 loanTokenAddress,
                 positionTokenAddress,
                 collateralTokenAddress,
                 loanTokenAmount,
                 positionTokenAmount,
-                collateralTokenAmount).div(maintenanceMarginAmount).div(10**16) <= (liquidationThresholdPercent));
+                collateralTokenAmount).div(maintenanceMarginAmount).div(10**16) <= (liquidationThresholdPercent)
+            );
     } 
 
     function isTradeSupported(
@@ -557,7 +566,6 @@ contract B0xOracle is Oracle_Interface, EIP20Wrapper, EMACollector, GasRefunder,
     /*
     * Owner functions
     */
-
     function setInterestFeePercent(
         uint newRate) 
         public
@@ -700,7 +708,6 @@ contract B0xOracle is Oracle_Interface, EIP20Wrapper, EMACollector, GasRefunder,
     /*
     * Internal functions
     */
-
     function _doTrade(
         address sourceTokenAddress,
         address destTokenAddress,
@@ -756,7 +763,7 @@ contract B0xOracle is Oracle_Interface, EIP20Wrapper, EMACollector, GasRefunder,
                     destTokenAddress,
                     VAULT_CONTRACT,
                     destTokenAmount)) {
-                    return intOrRevert(0,757); // revert("B0xOracle::_doTrade: _transferToken failed");
+                    return intOrRevert(0, 757); // revert("B0xOracle::_doTrade: _transferToken failed");
                 }
             } else {
                 // re-up the Kyber spend approval if needed

--- a/contracts/oracle/OracleRegistry.sol
+++ b/contracts/oracle/OracleRegistry.sol
@@ -19,7 +19,8 @@
 
 pragma solidity ^0.4.24;
 
-import 'openzeppelin-solidity/contracts/ownership/Ownable.sol';
+import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+
 
 /// @title Oracle Registry - Oracles added to the b0x network by decentralized governance
 contract OracleRegistry is Ownable {
@@ -65,7 +66,6 @@ contract OracleRegistry is Ownable {
         require(_address != address(0));
         _;
     }
-
 
     /// @dev Allows owner to add a new oracle to the registry.
     /// @param _oracle Address of new oracle.
@@ -127,8 +127,6 @@ contract OracleRegistry is Ownable {
         oracleByName[_name] = _oracle;
         oracle.name = _name;
     }
-
-
 
     /// @dev Checks if an oracle exists in the registry
     /// @param _oracle Address of registered oracle.

--- a/contracts/oracle/Oracle_Interface.sol
+++ b/contracts/oracle/Oracle_Interface.sol
@@ -1,6 +1,7 @@
 
 pragma solidity ^0.4.24;
 
+
 /**
     @title Oracle_Interface, an interface for b0x compatible oracle contracts
 
@@ -19,6 +20,7 @@ pragma solidity ^0.4.24;
 
     !!! Safeguard of user funds should be of the utmost importance !!!
  */
+// solhint-disable-next-line contract-name-camelcase
 interface Oracle_Interface {
 
     /// @dev Called by b0x after a loan order is taken

--- a/contracts/shared/Debugger.sol
+++ b/contracts/shared/Debugger.sol
@@ -1,8 +1,9 @@
 
 pragma solidity ^0.4.24;
 
+
 contract Debugger {
-    
+// solhint-disable-next-line var-name-mixedcase
     bool public DEBUG_MODE = false;
     
     event DebugLine(uint lineNumber);

--- a/contracts/shared/InternalFunctions.sol
+++ b/contracts/shared/InternalFunctions.sol
@@ -2,10 +2,11 @@
 
 pragma solidity ^0.4.24;
 
-import 'openzeppelin-solidity/contracts/math/SafeMath.sol';
-import '../modules/B0xStorage.sol';
-import '../B0xVault.sol';
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+import "../modules/B0xStorage.sol";
+import "../B0xVault.sol";
 import "../oracle/Oracle_Interface.sol";
+
 
 contract InternalFunctions is B0xStorage {
     using SafeMath for uint256;
@@ -251,7 +252,7 @@ contract InternalFunctions is B0xStorage {
             loanPosition.positionTokenAddressFilled,
             loanOrder.oracleAddress,
             loanPosition.positionTokenAmountFilled)) {
-            return intOrRevert(0,1441); // revert("InternalFunctions::_tradePositionWithOracle: B0xVault.withdrawToken failed");
+            return intOrRevert(0, 1441); // revert("InternalFunctions::_tradePositionWithOracle: B0xVault.withdrawToken failed");
         }
 
         uint tradeTokenAmountReceived;

--- a/contracts/tokens/BaseToken.sol
+++ b/contracts/tokens/BaseToken.sol
@@ -1,10 +1,11 @@
 
 pragma solidity ^0.4.24;
 
-import 'openzeppelin-solidity/contracts/token/ERC20/BurnableToken.sol';
+import "openzeppelin-solidity/contracts/token/ERC20/BurnableToken.sol";
 
-import './UnlimitedAllowanceToken.sol';
-//import './testing/fake/ERC827_AlwaysOwned.sol'; // Testing only! Please remove this and use above for production!
+import "./UnlimitedAllowanceToken.sol";
+//import "./testing/fake/ERC827_AlwaysOwned.sol"; // Testing only! Please remove this and use above for production!
+
 
 contract BaseToken is UnlimitedAllowanceToken, BurnableToken {
     string public name;

--- a/contracts/tokens/EIP20.sol
+++ b/contracts/tokens/EIP20.sol
@@ -1,7 +1,8 @@
 
 pragma solidity ^0.4.24;
 
-import 'openzeppelin-solidity/contracts/token/ERC20/ERC20.sol';
+import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
+
 
 /**
  * @title EIP20/ERC20 interface
@@ -14,6 +15,6 @@ contract EIP20 is ERC20 {
 }
 
 // Testing only! Please remove below and use above for non-dev environments!
-//import './testing/fake/ERC827_AlwaysOwned.sol';
+//import "./testing/fake/ERC827_AlwaysOwned.sol";
 //contract EIP20 is ERC827_AlwaysOwned {}
 

--- a/contracts/tokens/EIP20Wrapper.sol
+++ b/contracts/tokens/EIP20Wrapper.sol
@@ -1,11 +1,13 @@
 
 pragma solidity ^0.4.24;
 
+
 interface NonCompliantEIP20 {
     function transfer(address _to, uint _value) external;
     function transferFrom(address _from, address _to, uint _value) external;
     function approve(address _spender, uint _value) external;
 }
+
 
 /**
  * @title EIP20/ERC20 wrapper that will support noncompliant ERC20s

--- a/contracts/tokens/TokenRegistry.sol
+++ b/contracts/tokens/TokenRegistry.sol
@@ -19,7 +19,8 @@
 
 pragma solidity ^0.4.24;
 
-import 'openzeppelin-solidity/contracts/ownership/Ownable.sol';
+import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+
 
 contract TokenRegistry is Ownable {
 
@@ -81,7 +82,6 @@ contract TokenRegistry is Ownable {
         require(_address != address(0));
         _;
     }
-
 
     /// @dev Allows owner to add a new token to the registry.
     /// @param _token Address of new token.
@@ -194,7 +194,6 @@ contract TokenRegistry is Ownable {
     /*
      * View functions
      */
-
     /// @dev Provides a registered token's address when given the token symbol.
     /// @param _symbol Symbol of registered token.
     /// @return Token's address.

--- a/contracts/tokens/UnlimitedAllowanceToken.sol
+++ b/contracts/tokens/UnlimitedAllowanceToken.sol
@@ -18,7 +18,8 @@
 
 pragma solidity ^0.4.24;
 
-import 'openzeppelin-solidity/contracts/token/ERC827/ERC827Token.sol';
+import "openzeppelin-solidity/contracts/token/ERC827/ERC827Token.sol";
+
 
 contract UnlimitedAllowanceToken is ERC827Token {
 

--- a/contracts/tokens/b0xToken.sol
+++ b/contracts/tokens/b0xToken.sol
@@ -1,12 +1,13 @@
 
 pragma solidity ^0.4.24;
 
-import './BaseToken.sol';
+import "./BaseToken.sol";
+
 
 // 1 billion tokens (18 decimal places)
 contract B0xToken is BaseToken(
-	1000000000000000000000000000,
-	"b0x Protocol Token", 
-	18,
-	"B0X"
+    1000000000000000000000000000,
+    "b0x Protocol Token", 
+    18,
+    "B0X"
 ) {}

--- a/contracts/tokens/testing/TestNetB0xToken.sol
+++ b/contracts/tokens/testing/TestNetB0xToken.sol
@@ -1,11 +1,11 @@
 
 pragma solidity ^0.4.24;
 
-import '../BaseToken.sol';
+import "../BaseToken.sol";
 
 contract TestNetB0xToken is BaseToken(
-	10**(50+18),
-	"b0x Protocol Token", 
-	18,
-	"B0X"
+    10**(50+18),
+    "b0x Protocol Token", 
+    18,
+    "B0X"
 ) {}

--- a/contracts/tokens/testing/TestNetFaucet.sol
+++ b/contracts/tokens/testing/TestNetFaucet.sol
@@ -1,8 +1,8 @@
 
 pragma solidity ^0.4.24;
 
-import 'openzeppelin-solidity/contracts/ownership/Ownable.sol';
-import '../EIP20Wrapper.sol';
+import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import "../EIP20Wrapper.sol";
 
 contract TestNetFaucet is EIP20Wrapper, Ownable {
 

--- a/contracts/tokens/testing/TestNetOracle.sol
+++ b/contracts/tokens/testing/TestNetOracle.sol
@@ -1,7 +1,7 @@
 
 pragma solidity ^0.4.24;
 
-import '../../oracle/B0xOracle.sol';
+import "../../oracle/B0xOracle.sol";
 
 contract Faucet {
     function oracleExchange(

--- a/contracts/tokens/testing/TestToken0.sol
+++ b/contracts/tokens/testing/TestToken0.sol
@@ -1,12 +1,12 @@
 
 pragma solidity ^0.4.24;
 
-import '../BaseToken.sol';
+import "../BaseToken.sol";
 
 // 1 billion tokens (18 decimal places)
 contract TestToken0 is BaseToken(
-	10**(50+18),
-	"TestToken0", 
-	18,
-	"TEST0"
+    10**(50+18),
+    "TestToken0", 
+    18,
+    "TEST0"
 ) {}

--- a/contracts/tokens/testing/TestToken1.sol
+++ b/contracts/tokens/testing/TestToken1.sol
@@ -1,12 +1,12 @@
 
 pragma solidity ^0.4.24;
 
-import '../BaseToken.sol';
+import "../BaseToken.sol";
 
 // 1 billion tokens (18 decimal places)
 contract TestToken1 is BaseToken(
-	10**(50+18),
-	"TestToken1", 
-	18,
-	"TEST1"
+    10**(50+18),
+    "TestToken1", 
+    18,
+    "TEST1"
 ) {}

--- a/contracts/tokens/testing/TestToken2.sol
+++ b/contracts/tokens/testing/TestToken2.sol
@@ -1,12 +1,12 @@
 
 pragma solidity ^0.4.24;
 
-import '../BaseToken.sol';
+import "../BaseToken.sol";
 
 // 1 billion tokens (18 decimal places)
 contract TestToken2 is BaseToken(
-	10**(50+18),
-	"TestToken2", 
-	18,
-	"TEST2"
+    10**(50+18),
+    "TestToken2", 
+    18,
+    "TEST2"
 ) {}

--- a/contracts/tokens/testing/TestToken3.sol
+++ b/contracts/tokens/testing/TestToken3.sol
@@ -1,12 +1,12 @@
 
 pragma solidity ^0.4.24;
 
-import '../BaseToken.sol';
+import "../BaseToken.sol";
 
 // 1 billion tokens (18 decimal places)
 contract TestToken3 is BaseToken(
-	10**(50+18),
-	"TestToken3", 
-	18,
-	"TEST3"
+    10**(50+18),
+    "TestToken3", 
+    18,
+    "TEST3"
 ) {}

--- a/contracts/tokens/testing/TestToken4.sol
+++ b/contracts/tokens/testing/TestToken4.sol
@@ -1,12 +1,12 @@
 
 pragma solidity ^0.4.24;
 
-import '../BaseToken.sol';
+import "../BaseToken.sol";
 
 // 1 billion tokens (18 decimal places)
 contract TestToken4 is BaseToken(
-	10**(50+18),
-	"TestToken4", 
-	18,
-	"TEST4"
+    10**(50+18),
+    "TestToken4", 
+    18,
+    "TEST4"
 ) {}

--- a/contracts/tokens/testing/TestToken5.sol
+++ b/contracts/tokens/testing/TestToken5.sol
@@ -1,12 +1,12 @@
 
 pragma solidity ^0.4.24;
 
-import '../BaseToken.sol';
+import "../BaseToken.sol";
 
 // 1 billion tokens (18 decimal places)
 contract TestToken5 is BaseToken(
-	10**(50+18),
-	"TestToken5", 
-	18,
-	"TEST5"
+    10**(50+18),
+    "TestToken5", 
+    18,
+    "TEST5"
 ) {}

--- a/contracts/tokens/testing/TestToken6.sol
+++ b/contracts/tokens/testing/TestToken6.sol
@@ -1,12 +1,12 @@
 
 pragma solidity ^0.4.24;
 
-import '../BaseToken.sol';
+import "../BaseToken.sol";
 
 // 1 billion tokens (18 decimal places)
 contract TestToken6 is BaseToken(
-	10**(50+18),
-	"TestToken6", 
-	18,
-	"TEST6"
+    10**(50+18),
+    "TestToken6", 
+    18,
+    "TEST6"
 ) {}

--- a/contracts/tokens/testing/TestToken7.sol
+++ b/contracts/tokens/testing/TestToken7.sol
@@ -1,12 +1,12 @@
 
 pragma solidity ^0.4.24;
 
-import '../BaseToken.sol';
+import "../BaseToken.sol";
 
 // 1 billion tokens (18 decimal places)
 contract TestToken7 is BaseToken(
-	10**(50+18),
-	"TestToken7", 
-	18,
-	"TEST7"
+    10**(50+18),
+    "TestToken7", 
+    18,
+    "TEST7"
 ) {}

--- a/contracts/tokens/testing/TestToken8.sol
+++ b/contracts/tokens/testing/TestToken8.sol
@@ -1,12 +1,12 @@
 
 pragma solidity ^0.4.24;
 
-import '../BaseToken.sol';
+import "../BaseToken.sol";
 
 // 1 billion tokens (18 decimal places)
 contract TestToken8 is BaseToken(
-	10**(50+18),
-	"TestToken8", 
-	18,
-	"TEST8"
+    10**(50+18),
+    "TestToken8", 
+    18,
+    "TEST8"
 ) {}

--- a/contracts/tokens/testing/TestToken9.sol
+++ b/contracts/tokens/testing/TestToken9.sol
@@ -1,12 +1,12 @@
 
 pragma solidity ^0.4.24;
 
-import '../BaseToken.sol';
+import "../BaseToken.sol";
 
 // 1 billion tokens (18 decimal places)
 contract TestToken9 is BaseToken(
-	10**(50+18),
-	"TestToken9", 
-	18,
-	"TEST9"
+    10**(50+18),
+    "TestToken9", 
+    18,
+    "TEST9"
 ) {}

--- a/contracts/tokens/testing/fake/ERC20_AlwaysOwned.sol
+++ b/contracts/tokens/testing/fake/ERC20_AlwaysOwned.sol
@@ -1,7 +1,7 @@
 
 pragma solidity ^0.4.24;
 
-import 'openzeppelin-solidity/contracts/token/ERC20/StandardToken.sol';
+import "openzeppelin-solidity/contracts/token/ERC20/StandardToken.sol";
 
 
 /**

--- a/contracts/tokens/testing/fake/ERC827_AlwaysOwned.sol
+++ b/contracts/tokens/testing/fake/ERC827_AlwaysOwned.sol
@@ -1,7 +1,7 @@
 
 pragma solidity ^0.4.24;
 
-import './ERC20_AlwaysOwned.sol';
+import "./ERC20_AlwaysOwned.sol";
 
 
 /**

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "babel-preset-stage-3": "^6.24.1",
     "lodash": "^4.17.5",
     "minimist": "^1.2.0",
+    "solhint": "^1.2.1",
     "web3-utils": "^1.0.0-beta.34"
   },
   "dependencies": {
@@ -45,6 +46,7 @@
     "network:deployprev": "rimraf ./build/contracts && rimraf ./html_public_test && mkdirp ./build && node-mv ./test_network/build_contracts ./build/contracts && node-mv ./test_network/html_public_test ./html_public_test",
     "network:deploy0xdb": "rimraf ./test_network && mkdirp ./test_network && ziptool --unzip ./extra/0x_db_07d00cc515e0f9825b81595386b358593b7a3d6f.zip -o ./test_network",
     "network:run": "ganache-cli --networkId 50 -p 8545 --db ./test_network -m \"concert load couple harbor equip island argue ramp clarify fence smart topic\"",
-    "test": "truffle test ./test/endtoend.js"
+    "test": "truffle test ./test/endtoend.js",
+    "lint-contracts": "solhint contracts/**/*.sol"
   }
 }


### PR DESCRIPTION
## Adds Security and [Style Guide](http://solidity.readthedocs.io/en/develop/style-guide.html) checking and validation on solidity contracts.

This PR adds [Solhint](https://github.com/protofire/solhint) to achieve this goal.
I have only updated the code on those contracts where it had no impact on the functionality, mostly indentation issues. This should make code review fairly straightforward.


I have only configured the linter to output a warning instead of throwing errors as a starting point. Solhint can add more value. If you like this approach, more time can be invested analyzing and fixing those issues. Or you can simply update the linter configuration to ignore them without a warning.

Run:
`npm run lint-contracts`