### PR TITLE
Push Travis CI to use yarn instead of npm. Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,19 @@ language: node_js
 node_js:
   - '9'
 before_install:
+  - yarn cache clean
+  - yarn
+
   - export NODE_OPTIONS="--max_old_space_size=4096"
   - export PATH=$PATH:$(pwd)/node_modules/.bin
 install:
-  - npm i
+  - yarn cache clean
+  - yarn
 before_script:
-  - npm run network > /dev/null &
+  - yarn network > /dev/null &
   - sleep 5
 script:
-  - npm run test
+  - yarn test
 after_script:
-  - npm run network-coverage > /dev/null &
-  - travis_wait 40 npm run coverage && cat coverage/lcov.info | coveralls
+  - yarn network-coverage > /dev/null &
+  - travis_wait 40 yarn coverage && cat coverage/lcov.info | coveralls

--- a/contracts/modules/BZxOrderTaking.sol
+++ b/contracts/modules/BZxOrderTaking.sol
@@ -103,10 +103,11 @@ contract BZxOrderTaking is BZxStorage, Proxiable, InternalFunctions {
             orderValues,
             signature);
 
+        // lenders have to fill the entire uncanceled loanTokenAmount
         return _takeLoanOrder(
             loanOrderHash,
             orderAddresses[3], // collateralTokenFilled
-            orderValues[0], // loanTokenAmountFilled
+            orderValues[0].sub(getUnavailableLoanTokenAmount(loanOrderHash)), // loanTokenAmountFilled
             0 // takerRole
         );
     }
@@ -176,10 +177,11 @@ contract BZxOrderTaking is BZxStorage, Proxiable, InternalFunctions {
         tracksGas
         returns (uint)
     {
+        // lenders have to fill the entire uncanceled loanTokenAmount
         return _takeLoanOrder(
             loanOrderHash,
             orders[loanOrderHash].collateralTokenAddress,
-            orders[loanOrderHash].loanTokenAmount,
+            orders[loanOrderHash].loanTokenAmount.sub(getUnavailableLoanTokenAmount(loanOrderHash)),
             0 // takerRole
         );
     }
@@ -703,7 +705,7 @@ contract BZxOrderTaking is BZxStorage, Proxiable, InternalFunctions {
                 });
             }
         } else { // remainingLoanTokenAmount == loanTokenAmountFilled
-             _removeLoanOrder(loanOrder.loanOrderHash);
+            _removeLoanOrder(loanOrder.loanOrderHash);
         }
 
         return true;

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "rimraf": "^2.6.2",
     "truffle": "^4.1.14",
     "truffle-hdwallet-provider": "0.0.3",
-    "ziptool": "^1.0.2"
+    "ziptool": "git+https://github.com/nayayayay/ziptool.git"
   },
   "scripts": {
     "blockchain": "./extra/restart_blockchain.sh",

--- a/test/endtoend.js
+++ b/test/endtoend.js
@@ -697,7 +697,7 @@ contract('BZxTest', function(accounts) {
 
   (run["should take sample loan order (as lender2)"] ? it : it.skip)("should take sample loan order (as lender2)", async function() {
     //const provider = new providers.Web3Provider(web3.currentProvider);
-    
+
     try {
       let tx = await bZx.takeLoanOrderAsLender(
         [
@@ -720,10 +720,10 @@ contract('BZxTest', function(accounts) {
           new BN(OrderParams_bZx_2["salt"])
         ],
         ECSignature_raw_2,
-        {from: lender2_account, gas: 1000000, gasPrice: web3.toWei(30, "gwei")});
-        
+        {from: lender2_account, gasPrice: web3.toWei(30, "gwei")});
+
       console.log(txPrettyPrint(tx,"should take sample loan order (as lender2)"));
-          
+
       /*tx = (await provider.send("debug_traceTransaction", [ tx.tx, {} ]));
       console.log(JSON.stringify(tx, null, '\t'));*/
 
@@ -1625,7 +1625,7 @@ contract('BZxTest', function(accounts) {
 
     OrderHash_0xV2_1 = ZeroExV2.getOrderHashHex(OrderParams_0xV2_1);
     OrderHash_0xV2_2 = ZeroExV2.getOrderHashHex(OrderParams_0xV2_2);
-    
+
     console.log("OrderHash_0xV2_1 with 0x.js: "+OrderHash_0xV2_1);
     console.log("OrderHash_0xV2_2 with 0x.js: "+OrderHash_0xV2_2);
 
@@ -1661,7 +1661,7 @@ contract('BZxTest', function(accounts) {
       OrderParams_0xV2_2["makerAssetData"],
       OrderParams_0xV2_2["takerAssetData"]
     ];
-  
+
 
     // using ethers.js for ABI v2 encoding
     const provider = await (new providers.Web3Provider(web3.currentProvider));
@@ -1669,9 +1669,9 @@ contract('BZxTest', function(accounts) {
     const helper = await (new Contract(zeroExV2Helper.address, zeroExV2Helper.abi, signer));
     OrderHash_0xV2_1_onchain = await helper.getOrderHash(OrderParams_0xV2_1_prepped);
     OrderHash_0xV2_2_onchain = await helper.getOrderHash(OrderParams_0xV2_2_prepped);
-    
+
     console.log("OrderHash_0xV2_1 with contracts: "+OrderHash_0xV2_1_onchain);
-    console.log("OrderHash_0xV2_2 with contracts: "+OrderHash_0xV2_2_onchain);    
+    console.log("OrderHash_0xV2_2 with contracts: "+OrderHash_0xV2_2_onchain);
     /*
     if (ZeroExV2.isValidOrderHash(OrderHash_0xV2_1))
       console.log("valid1 -> true");
@@ -1686,7 +1686,7 @@ contract('BZxTest', function(accounts) {
     ECSignature_0xV2_1 = await zeroExV2.ecSignOrderHashAsync(
       OrderHash_0xV2_1_onchain,
       OrderParams_0xV2_1["makerAddress"],
-      { 
+      {
         prefixType: "ETH_SIGN",
         shouldAddPrefixBeforeCallingEthSign: false
       }
@@ -1698,7 +1698,7 @@ contract('BZxTest', function(accounts) {
     ECSignature_0xV2_2 = await zeroExV2.ecSignOrderHashAsync(
       OrderHash_0xV2_2_onchain,
       OrderParams_0xV2_2["makerAddress"],
-      { 
+      {
         prefixType: "ETH_SIGN",
         shouldAddPrefixBeforeCallingEthSign: false
       }
@@ -1741,7 +1741,7 @@ contract('BZxTest', function(accounts) {
     try {
       let tx = await bZx.sendTransaction({data: txData, from: trader1_account})
       console.log(await txPrettyPrint(tx,"should trade position with 0x V2 orders"));
-      
+
       //tx = await provider.send("debug_traceTransaction", [ tx.tx, {} ]);
       //return provider.getTransactionReceipt(tx.hash);
       //console.log(JSON.stringify(tx, null, '\t'));
@@ -1749,7 +1749,7 @@ contract('BZxTest', function(accounts) {
       assert.isOk(tx);
     } catch (error) {
       console.log(error);
-     
+
       /*var matches = error.message.match(/Transaction: ([^ ]+) exited/);
       console.log(matches[1]);
       provider.send("debug_traceTransaction", [ matches[1], {} ]).then(function(tx) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10031,3 +10031,10 @@ ziptool@^1.0.2:
   dependencies:
     archiver "^2.0.3"
     unzip "^0.1.11"
+
+"ziptool@git+https://github.com/nayayayay/ziptool.git":
+  version "1.0.2"
+  resolved "git+https://github.com/nayayayay/ziptool.git#f8890628b10a2f4793f5ecdf58f5a35ac461f6ac"
+  dependencies:
+    archiver "^2.0.3"
+    unzip "^0.1.11"


### PR DESCRIPTION
- Push Travis CI to use yarn instead of npm. Update .travis.yml
- Fix ziptool dependency: get rid of CRLF line terminators, force load this package directly from github
- Fix `should take sample loan order (as lender2)` test: remove `gas` because `out of gas` during test coverage
- cherry-pick [deb121de] from `master` branch with some fixes